### PR TITLE
Add configurable log paths and timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ Make sure:
 - Your domain DNS points to the host
 - Traefik is configured with TLS/SSL (e.g., Let's Encrypt)
 
+### 4. Environment variables
+
+You can override default log locations and timezone with environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENVPN_MONITOR_TZ` | `Europe/Bucharest` | Timezone used to compute session durations. |
+| `OPENVPN_STATUS_LOG` | `/var/log/openvpn/status.log` | Path to the OpenVPN status log parsed for active clients. |
+| `OPENVPN_HISTORY_LOG` | `/var/log/openvpn/session_history.log` | File used to persist session history entries. |
+| `OPENVPN_ACTIVE_SESSIONS` | `/var/log/openvpn/active_sessions.json` | JSON file storing in-progress sessions. |
+| `OPENVPN_SERVER_STATUS` | `/var/log/openvpn/server_status.json` | Optional JSON file with aggregated server status information. |
+
+Example `docker-compose.yml` override:
+
+```yaml
+environment:
+  OPENVPN_MONITOR_TZ: "Europe/Prague"
+  OPENVPN_STATUS_LOG: "/data/openvpn/status.log"
+```
+
 ---
 
 ## 🌐 Access the Interface

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,27 @@
+"""Application configuration helpers for log parsing and API."""
+import os
+
+import pytz
+
+_DEFAULT_TIMEZONE = "Europe/Bucharest"
+
+
+def _load_timezone():
+    tz_name = os.getenv("OPENVPN_MONITOR_TZ", _DEFAULT_TIMEZONE)
+    try:
+        return pytz.timezone(tz_name)
+    except pytz.UnknownTimeZoneError:
+        # Fallback to default to keep the application running.
+        return pytz.timezone(_DEFAULT_TIMEZONE)
+
+
+def _load_path(env_var: str, default: str) -> str:
+    path = os.getenv(env_var, default)
+    return os.path.expanduser(path)
+
+
+LOCAL_TZ = _load_timezone()
+STATUS_LOG_PATH = _load_path("OPENVPN_STATUS_LOG", "/var/log/openvpn/status.log")
+HISTORY_LOG_PATH = _load_path("OPENVPN_HISTORY_LOG", "/var/log/openvpn/session_history.log")
+ACTIVE_SESSIONS_PATH = _load_path("OPENVPN_ACTIVE_SESSIONS", "/var/log/openvpn/active_sessions.json")
+SERVER_STATUS_PATH = _load_path("OPENVPN_SERVER_STATUS", "/var/log/openvpn/server_status.json")

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,5 +1,6 @@
 #routes.py
 from flask import Flask, render_template, jsonify
+from .config import HISTORY_LOG_PATH, SERVER_STATUS_PATH
 from .parser import parse_status_log
 import os
 import json
@@ -41,10 +42,9 @@ def api_clients():
 @app.route('/api/history')
 def get_history():
     entries = []
-    log_path = "/var/log/openvpn/session_history.log"
     try:
-        if os.path.exists(log_path):
-            with open(log_path, "r") as f:
+        if os.path.exists(HISTORY_LOG_PATH):
+            with open(HISTORY_LOG_PATH, "r") as f:
                 for line in f:
                     parts = line.strip().split(',')[:9]
                     if len(parts) == 9 and parts[4] and parts[5] and is_valid_datetime(parts[8]):
@@ -71,7 +71,7 @@ def get_history():
 @app.route('/api/server-status')
 def get_server_status():
     try:
-        with open("/var/log/openvpn/server_status.json", "r") as f:
+        with open(SERVER_STATUS_PATH, "r") as f:
             data = json.load(f)
 
         # ?? ????????? ?????? "Yes" ? ?????? ????????


### PR DESCRIPTION
## Summary
- add a dedicated configuration module for timezone and log file paths
- update the parser and API routes to consume the shared configuration
- document the new environment variables and overrides in the README

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d7f41f8ba08329b39250809709b956