### PR TITLE
Improve session storage reliability

### DIFF
--- a/app/parser.py
+++ b/app/parser.py
@@ -3,7 +3,11 @@
 import datetime
 import json
 import os
+import tempfile
 import uuid
+from contextlib import contextmanager
+
+import fcntl
 from .config import (
     ACTIVE_SESSIONS_PATH,
     HISTORY_LOG_PATH,
@@ -14,15 +18,76 @@ from .config import (
 def format_duration(seconds):
     return str(datetime.timedelta(seconds=seconds))
 
+def validate_active_sessions(data):
+    if not isinstance(data, dict):
+        return {}
+
+    required_fields = {"ip", "vpn_ip", "connected_at", "bytes_received", "bytes_sent", "session_id"}
+    validated = {}
+
+    for common_name, session in data.items():
+        if not isinstance(common_name, str) or not isinstance(session, dict):
+            continue
+
+        if not required_fields.issubset(session.keys()):
+            continue
+
+        try:
+            bytes_received = int(session["bytes_received"])
+            bytes_sent = int(session["bytes_sent"])
+        except (TypeError, ValueError):
+            continue
+
+        validated[common_name] = {
+            **session,
+            "bytes_received": bytes_received,
+            "bytes_sent": bytes_sent,
+        }
+
+    return validated
+
+
 def load_active_sessions(path: str = ACTIVE_SESSIONS_PATH):
-    if os.path.exists(path):
-        with open(path, "r") as f:
-            return json.load(f)
+    target_path = os.path.abspath(path)
+
+    if os.path.exists(target_path):
+        try:
+            with open(target_path, "r") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+        return validate_active_sessions(data)
     return {}
 
+
 def save_active_sessions(sessions, path: str = ACTIVE_SESSIONS_PATH):
-    with open(path, "w") as f:
-        json.dump(sessions, f)
+    target_path = os.path.abspath(path)
+    directory = os.path.dirname(target_path)
+    os.makedirs(directory, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile("w", dir=directory, delete=False) as tmp_file:
+        json.dump(sessions, tmp_file)
+        tmp_file.flush()
+        os.fsync(tmp_file.fileno())
+
+    os.replace(tmp_file.name, target_path)
+
+
+@contextmanager
+def history_log(path: str = HISTORY_LOG_PATH):
+    target_path = os.path.abspath(path)
+    directory = os.path.dirname(target_path)
+    os.makedirs(directory, exist_ok=True)
+
+    with open(target_path, "a") as logf:
+        fcntl.flock(logf, fcntl.LOCK_EX)
+        try:
+            yield logf
+        finally:
+            logf.flush()
+            os.fsync(logf.fileno())
+            fcntl.flock(logf, fcntl.LOCK_UN)
 
 def parse_status_log(filepath=STATUS_LOG_PATH):
     clients = []
@@ -100,8 +165,10 @@ def parse_status_log(filepath=STATUS_LOG_PATH):
                             "port": port,
                             "session_id": session_id
                         }
-                        with open(HISTORY_LOG_PATH, "a") as logf:
-                            logf.write(f"{active_sessions[common_name]['connected_at']},{common_name},{real_ip},{session_id},,,,{vpn_ip},{port}\n")
+                        with history_log() as logf:
+                            logf.write(
+                                f"{active_sessions[common_name]['connected_at']},{common_name},{real_ip},{session_id},,,,{vpn_ip},{port}\n"
+                            )
                     else:
                         active_sessions[common_name]["bytes_received"] = bytes_received
                         active_sessions[common_name]["bytes_sent"] = bytes_sent
@@ -112,8 +179,10 @@ def parse_status_log(filepath=STATUS_LOG_PATH):
             rx = round(session["bytes_received"] / (1024 * 1024), 2)
             tx = round(session["bytes_sent"] / (1024 * 1024), 2)
             disconnect_time = now.strftime("%Y-%m-%d %H:%M:%S")
-            with open(HISTORY_LOG_PATH, "a") as logf:
-                logf.write(f"{session['connected_at']},{cn},{session['ip']},{session['session_id']},{rx},{tx},{session.get('vpn_ip')},{session.get('port')},{disconnect_time}\n")
+            with history_log() as logf:
+                logf.write(
+                    f"{session['connected_at']},{cn},{session['ip']},{session['session_id']},{rx},{tx},{session.get('vpn_ip')},{session.get('port')},{disconnect_time}\n"
+                )
 #               logf.write(f"{session['connected_at']},{cn},{session['ip']},{session['session_id']},{rx},{tx},{session.get('vpn_ip')},{session.get('port')},{disconnect_time}\n")
             del active_sessions[cn]
 # {session['connected_at']}


### PR DESCRIPTION
## Summary
- add schema validation when reading active session cache
- save active sessions atomically via temporary file replacement
- serialize history updates through a file lock helper

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d7f7743d30832988469e072d5c6204