### PR TITLE
Refactor status parser for streaming log processing

### DIFF
--- a/app/parser.py
+++ b/app/parser.py
@@ -2,10 +2,12 @@
 # parser.py
 import datetime
 import json
+import logging
 import os
 import tempfile
 import uuid
 from contextlib import contextmanager
+from ipaddress import ip_address
 
 import fcntl
 from .config import (
@@ -14,6 +16,9 @@ from .config import (
     LOCAL_TZ,
     STATUS_LOG_PATH,
 )
+
+
+logger = logging.getLogger(__name__)
 
 def format_duration(seconds):
     return str(datetime.timedelta(seconds=seconds))
@@ -89,105 +94,162 @@ def history_log(path: str = HISTORY_LOG_PATH):
             os.fsync(logf.fileno())
             fcntl.flock(logf, fcntl.LOCK_UN)
 
+def _split_real_address(address: str):
+    if not address:
+        return "", ""
+
+    value = address.strip()
+
+    if value.startswith("["):
+        if "]:" in value:
+            ip_part, port_part = value.split("]:", 1)
+            return ip_part.lstrip("["), port_part
+        return value.strip("[]"), ""
+
+    try:
+        ip_address(value)
+        return value, ""
+    except ValueError:
+        if ":" in value:
+            ip_part, port_part = value.rsplit(":", 1)
+            if port_part.isdigit():
+                try:
+                    ip_address(ip_part)
+                    return ip_part, port_part
+                except ValueError:
+                    pass
+        return value, ""
+
+
 def parse_status_log(filepath=STATUS_LOG_PATH):
     clients = []
     active_sessions = load_active_sessions()
     current_common_names = set()
     vpn_ip_map = {}
+    new_sessions = []
+    client_records = []
+    now = datetime.datetime.now(LOCAL_TZ)
 
     try:
         with open(filepath, "r") as f:
-            lines = f.readlines()
-#Moved here
-        now = datetime.datetime.now(LOCAL_TZ)
-        routing_section = False
-        for line in lines:
-            if line.startswith("ROUTING TABLE"):
-                routing_section = True
-                continue
-            if routing_section:
-                if line.strip() == "" or line.startswith("GLOBAL STATS"):
-                    break
-                parts = line.strip().split(',')
-                if len(parts) >= 2:
-                    vpn_ip = parts[0]
-                    common_name = parts[1]
-                    vpn_ip_map[common_name] = vpn_ip
+            section = None
 
-        client_section = False
-        for line in lines:
-            if line.startswith("Common Name,Real Address,Bytes Received,Bytes Sent,Connected Since"):
-                client_section = True
-                continue
-            if client_section:
-                if line.strip() == "" or line.startswith("ROUTING TABLE"):
-                    break
-                parts = line.strip().split(',')
-                if len(parts) >= 5:
+            for raw_line in f:
+                line = raw_line.strip()
+
+                if raw_line.startswith("Common Name,Real Address,Bytes Received,Bytes Sent,Connected Since"):
+                    section = "clients"
+                    continue
+
+                if raw_line.startswith("ROUTING TABLE"):
+                    section = "routing"
+                    continue
+
+                if raw_line.startswith("GLOBAL STATS"):
+                    section = None
+                    continue
+
+                if not line:
+                    if section in {"clients", "routing"}:
+                        section = None
+                    continue
+
+                if section == "routing":
+                    parts = line.split(",")
+                    if len(parts) >= 2:
+                        vpn_ip = parts[0]
+                        common_name = parts[1]
+                        vpn_ip_map[common_name] = vpn_ip
+                    continue
+
+                if section == "clients":
+                    parts = line.split(",")
+                    if len(parts) < 5:
+                        continue
+
                     common_name = parts[0]
-# ??????????? ?????????? ????????
-                    real_address = parts[1]
-                    if real_address.count(':') > 1:
-                        real_ip = real_address  # IPv6, ???????? ??? ?????
-                        port = None
-                    else:
-                        real_ip, port = real_address.rsplit(":", 1) if ":" in real_address else (real_address, None)
+                    real_ip, port = _split_real_address(parts[1])
                     bytes_received = int(parts[2])
                     bytes_sent = int(parts[3])
                     connected_since = parts[4]
+
                     naive_dt = datetime.datetime.strptime(connected_since, "%Y-%m-%d %H:%M:%S")
                     connected_dt = LOCAL_TZ.localize(naive_dt)
-#
-#                    now = datetime.datetime.now(LOCAL_TZ)
                     time_online = format_duration(int((now - connected_dt).total_seconds()))
-                    vpn_ip = vpn_ip_map.get(common_name)
 
-                    clients.append({
-                        'common_name': common_name,
-                        'vpn_ip': vpn_ip,
-                        'real_ip': real_ip,
-                        'port': port,
-                        'bytes_received': bytes_received,
-                        'bytes_sent': bytes_sent,
-                        'connected_since': connected_since,
-                        'time_online': time_online
-                    })
+                    client_records.append(
+                        {
+                            "common_name": common_name,
+                            "real_ip": real_ip,
+                            "port": port,
+                            "bytes_received": bytes_received,
+                            "bytes_sent": bytes_sent,
+                            "connected_since": connected_since,
+                            "time_online": time_online,
+                        }
+                    )
+
                     current_common_names.add(common_name)
 
                     if common_name not in active_sessions:
                         session_id = str(uuid.uuid4())
                         active_sessions[common_name] = {
                             "ip": real_ip,
-                            "vpn_ip": vpn_ip,
+                            "vpn_ip": None,
                             "connected_at": connected_dt.strftime("%Y-%m-%d %H:%M:%S"),
                             "bytes_received": bytes_received,
                             "bytes_sent": bytes_sent,
                             "port": port,
-                            "session_id": session_id
+                            "session_id": session_id,
                         }
-                        with history_log() as logf:
-                            logf.write(
-                                f"{active_sessions[common_name]['connected_at']},{common_name},{real_ip},{session_id},,,,{vpn_ip},{port}\n"
-                            )
+                        new_sessions.append(common_name)
                     else:
                         active_sessions[common_name]["bytes_received"] = bytes_received
                         active_sessions[common_name]["bytes_sent"] = bytes_sent
+                        active_sessions[common_name]["ip"] = real_ip
+                        active_sessions[common_name]["port"] = port
 
-        disconnected = [cn for cn in active_sessions if cn not in current_common_names]
+        for record in client_records:
+            common_name = record["common_name"]
+            vpn_ip = vpn_ip_map.get(common_name)
+            record["vpn_ip"] = vpn_ip
+            clients.append(record)
+
+            if common_name in active_sessions:
+                active_sessions[common_name]["vpn_ip"] = vpn_ip
+
+        for common_name in new_sessions:
+            session = active_sessions.get(common_name)
+            if not session:
+                continue
+
+            vpn_ip = vpn_ip_map.get(common_name) or ""
+            port = session.get("port") or ""
+
+            session["vpn_ip"] = vpn_ip or None
+
+            with history_log() as logf:
+                logf.write(
+                    f"{session['connected_at']},{common_name},{session['ip']},{session['session_id']},,,,{vpn_ip},{port}\n"
+                )
+
+        disconnected = [cn for cn in list(active_sessions) if cn not in current_common_names]
         for cn in disconnected:
             session = active_sessions[cn]
             rx = round(session["bytes_received"] / (1024 * 1024), 2)
             tx = round(session["bytes_sent"] / (1024 * 1024), 2)
             disconnect_time = now.strftime("%Y-%m-%d %H:%M:%S")
+            vpn_ip = session.get("vpn_ip") or ""
+            port = session.get("port") or ""
+
             with history_log() as logf:
                 logf.write(
-                    f"{session['connected_at']},{cn},{session['ip']},{session['session_id']},{rx},{tx},{session.get('vpn_ip')},{session.get('port')},{disconnect_time}\n"
+                    f"{session['connected_at']},{cn},{session['ip']},{session['session_id']},{rx},{tx},{vpn_ip},{port},{disconnect_time}\n"
                 )
-#               logf.write(f"{session['connected_at']},{cn},{session['ip']},{session['session_id']},{rx},{tx},{session.get('vpn_ip')},{session.get('port')},{disconnect_time}\n")
+
             del active_sessions[cn]
-# {session['connected_at']}
-    except Exception as e:
-        print(f"Error parsing log: {e}")
+    except Exception:  # pragma: no cover - safeguard logging
+        logger.exception("Error parsing status log")
 
     save_active_sessions(active_sessions)
     return clients


### PR DESCRIPTION
## Summary
- refactor `parse_status_log` to iterate over the status file once while caching client and routing data
- normalize real address parsing to retain IPv6 ports and log parser failures through the logging module
- defer history updates until routing data is known while keeping session files consistent

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d7fa0ef68883299c52a083cdc074f9