### PR TITLE
Synchronize client and server polling intervals

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -220,10 +220,13 @@ let chartCanvas = null;
 
 // ИНИЦИАЛИЗАЦИЯ
 document.addEventListener("DOMContentLoaded", function () {
-  fetchData();
-  setInterval(fetchData, 2000);
-  fetchServerStatus();
-  setInterval(fetchServerStatus, 3000);
+  const refreshAll = () => {
+    fetchData();
+    fetchServerStatus();
+  };
+
+  refreshAll();
+  setInterval(refreshAll, 1000);
   
   /*
   document.getElementById("toggleGraphBtn").addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- refresh both client list and server status together every second to keep the UI in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80c6018a08329965e9d92ee06a39a