### PR TITLE
Add IPv4/IPv6 columns to VPN clients table

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -47,7 +47,8 @@
       <thead class="table-light">
         <tr>
           <th>Client</th>
-          <th>VPN IP</th>
+          <th>VPN IPV4</th>
+          <th>VPN IPV6</th>
           <th>Client IP</th>
           <th>Port</th>
           <th>Session Opened</th>
@@ -61,7 +62,7 @@
       <tbody id="vpn-clients-body"></tbody>
       <tfoot class="table-light">
         <tr>
-          <th colspan="7">Total</th>
+          <th colspan="8">Total</th>
           <th id="total-received">0 MB</th>
           <th id="total-sent">0 MB</th>
         </tr>
@@ -554,8 +555,25 @@ function fetchData(forceInitChart = false) {
         if (datasetMap[`${client.common_name} Tx`].length > 20) datasetMap[`${client.common_name} Tx`].shift();
       }
 
+      const ipv4Candidate = client.vpn_ipv4 ?? null;
+      const ipv6Candidate = client.vpn_ipv6 ?? null;
+
+      let vpnIPv4 = ipv4Candidate;
+      let vpnIPv6 = ipv6Candidate;
+
+      if (vpnIPv4 == null && vpnIPv6 == null && client.vpn_ip) {
+        if (client.vpn_ip.includes(':')) {
+          vpnIPv6 = client.vpn_ip;
+        } else {
+          vpnIPv4 = client.vpn_ip;
+        }
+      }
+
+      const displayIPv4 = vpnIPv4 ?? "";
+      const displayIPv6 = vpnIPv6 && vpnIPv6.trim() ? vpnIPv6 : "—";
+
       return `<tr>
-        <td>${client.common_name}</td><td>${client.vpn_ip ?? ""}</td><td>${client.real_ip}</td><td>${client.port ?? ""}</td>
+        <td>${client.common_name}</td><td>${displayIPv4}</td><td>${displayIPv6}</td><td>${client.real_ip}</td><td>${client.port ?? ""}</td>
         <td>${client.connected_since}</td><td>${client.time_online}</td>
         <td>${speed_rx.toFixed(2)} / ${speed_tx.toFixed(2)} MB/s</td>
         <td>${(client.bytes_received / 1024 / 1024).toFixed(2)} MB</td>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -63,6 +63,7 @@ client1,[2001:db8::1]:443,1024,2048,2024-01-01 12:00:00
 
 ROUTING TABLE
 10.8.0.2,client1
+2001:db8:abcd::100,client1
 """.strip()
     )
 
@@ -82,6 +83,8 @@ ROUTING TABLE
     assert client["bytes_sent"] == 2048
     assert client["connected_since"] == "2024-01-01 12:00:00"
     assert client["vpn_ip"] == "10.8.0.2"
+    assert client["vpn_ipv4"] == "10.8.0.2"
+    assert client["vpn_ipv6"] == "2001:db8:abcd::100"
     assert client["time_online"].startswith("0:")
 
     with active_path.open() as fh:
@@ -173,6 +176,8 @@ ROUTING TABLE
 
     assert clients[0]["common_name"] == "alice"
     assert clients[0]["vpn_ip"] == "10.8.0.6"
+    assert clients[0]["vpn_ipv4"] == "10.8.0.6"
+    assert clients[0]["vpn_ipv6"] is None
     assert clients[0]["real_ip"] == "198.51.100.20"
     assert clients[0]["port"] == "51820"
 


### PR DESCRIPTION
## Summary
- capture IPv4 and IPv6 VPN addresses separately when parsing the OpenVPN status log
- expose the split addresses via the clients API and show them in dedicated columns in the UI
- extend parser tests to cover IPv6 routing entries and the new data shape

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d80ef1731c8329afc5c15cf48b1258