### PR TITLE
Add IPv4/IPv6 data to connection history logging

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -132,7 +132,8 @@
               <tr>
                 <th>Session Opened</th>
                 <th>Client</th>
-                <th>VPN IP</th>
+                <th>VPN IPV4</th>
+                <th>VPN IPV6</th>
                 <th>Client IP</th>
                 <th>Port</th>
                 <th>Session Closed</th>
@@ -478,13 +479,20 @@ function applyFilters() {
 }
 
 function renderHistoryTable(data) {
-  const rows = data.map(e => `
-    <tr>
-      <td>${e.timestamp}</td><td>${e.name}</td><td>${e.vpn_ip ?? ""}</td><td>${e.ip}</td>
-      <td>${e.port ?? ""}</td><td>${e.session_end ?? ""}</td>
-      <td>${e.duration ?? ""}</td><td>${e.rx ?? ""}</td><td>${e.tx ?? ""}</td>
-    </tr>
-  `).join("");
+  const rows = data.map(e => {
+    const legacyVpnIp = e.vpn_ip ?? "";
+    const vpnIpv4 = e.vpn_ipv4 || (legacyVpnIp && legacyVpnIp.includes('.') ? legacyVpnIp : "");
+    const rawIpv6 = e.vpn_ipv6 || (legacyVpnIp && legacyVpnIp.includes(':') ? legacyVpnIp : "");
+    const vpnIpv6 = rawIpv6 || "—";
+
+    return `
+      <tr>
+        <td>${e.timestamp}</td><td>${e.name}</td><td>${vpnIpv4}</td><td>${vpnIpv6}</td><td>${e.ip}</td>
+        <td>${e.port ?? ""}</td><td>${e.session_end ?? ""}</td>
+        <td>${e.duration ?? ""}</td><td>${e.rx ?? ""}</td><td>${e.tx ?? ""}</td>
+      </tr>
+    `;
+  }).join("");
   document.getElementById("history-body").innerHTML = rows;
 }
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -92,6 +92,8 @@ ROUTING TABLE
 
     assert data["client1"]["port"] == "443"
     assert data["client1"]["vpn_ip"] == "10.8.0.2"
+    assert data["client1"]["vpn_ipv4"] == "10.8.0.2"
+    assert data["client1"]["vpn_ipv6"] == "2001:db8:abcd::100"
 
     history_entries = history_path.read_text().strip().split(",")
     assert history_entries == [
@@ -104,6 +106,9 @@ ROUTING TABLE
         "",
         "10.8.0.2",
         "443",
+        "",
+        "10.8.0.2",
+        "2001:db8:abcd::100",
     ]
 
 
@@ -145,8 +150,7 @@ ROUTING TABLE
     history_line = history_path.read_text().strip()
     assert history_line == (
         "2024-01-01 09:00:00,alice,198.51.100.10,existing-session,1.0,2.0,"
-        "10.8.0.5,443,"
-        "2024-01-01 13:00:00"
+        "10.8.0.5,443,2024-01-01 13:00:00,10.8.0.5,"
     )
 
 
@@ -188,6 +192,8 @@ ROUTING TABLE
         "alice": {
             "ip": "198.51.100.20",
             "vpn_ip": "10.8.0.6",
+            "vpn_ipv4": "10.8.0.6",
+            "vpn_ipv6": None,
             "connected_at": "2024-01-01 11:45:00",
             "bytes_received": 2048,
             "bytes_sent": 1024,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,65 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+@pytest.fixture
+def app_client(tmp_path, monkeypatch):
+    history_path = tmp_path / "history.log"
+
+    monkeypatch.setenv("OPENVPN_HISTORY_LOG", str(history_path))
+
+    from app import config
+
+    importlib.reload(config)
+
+    from app import routes
+
+    importlib.reload(routes)
+
+    routes.app.config.update(TESTING=True)
+    client = routes.app.test_client()
+
+    return client, history_path
+
+
+def test_api_history_includes_vpn_ip_versions(app_client):
+    client, history_path = app_client
+
+    history_path.write_text(
+        "\n".join(
+            [
+                "2024-01-01 09:00:00,alice,198.51.100.10,s1,1.0,2.0,10.8.0.5,443,2024-01-01 10:00:00",
+                "2024-01-02 09:00:00,bob,203.0.113.5,s2,3.0,4.0,10.9.0.2,1194,2024-01-02 11:00:00,10.9.0.2,2001:db8::abcd",
+                "2024-01-03 09:00:00,carol,2001:db8::10,s3,5.0,6.0,2001:db8::ffff,1194,2024-01-03 10:00:00",
+            ]
+        )
+    )
+
+    response = client.get("/api/history")
+    assert response.status_code == 200
+
+    entries = json.loads(response.data)
+    assert len(entries) == 3
+
+    alice, bob, carol = entries
+
+    assert alice["vpn_ip"] == "10.8.0.5"
+    assert alice["vpn_ipv4"] == "10.8.0.5"
+    assert alice["vpn_ipv6"] == ""
+
+    assert bob["vpn_ip"] == "10.9.0.2"
+    assert bob["vpn_ipv4"] == "10.9.0.2"
+    assert bob["vpn_ipv6"] == "2001:db8::abcd"
+
+    assert carol["vpn_ip"] == "2001:db8::ffff"
+    assert carol["vpn_ipv4"] == ""
+    assert carol["vpn_ipv6"] == "2001:db8::ffff"


### PR DESCRIPTION
## Summary
- persist VPN IPv4 and IPv6 addresses in history log entries and ensure active sessions keep the new values
- expose vpn_ipv4 and vpn_ipv6 through /api/history with legacy fallbacks and update the history modal to show both columns
- extend parser coverage and add a routes test to validate the revised history payload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8122c3ccc8329bc95e34c304ddcbe