### PR TITLE
Format parser module and tests with Black

### DIFF
--- a/app/parser.py
+++ b/app/parser.py
@@ -164,9 +164,7 @@ def parse_status_log(filepath=STATUS_LOG_PATH):
                         vpn_ip = parts[0].strip()
                         common_name = parts[1].strip()
 
-                        entry = vpn_ip_map.setdefault(
-                            common_name, {"ipv4": None, "ipv6": None}
-                        )
+                        entry = vpn_ip_map.setdefault(common_name, {"ipv4": None, "ipv6": None})
 
                         try:
                             ip_obj = ip_address(vpn_ip)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -154,9 +154,7 @@ ROUTING TABLE
     )
 
 
-def test_parse_status_log_recovers_from_corrupted_state(
-    parser_module, monkeypatch
-):
+def test_parse_status_log_recovers_from_corrupted_state(parser_module, monkeypatch):
     parser, status_path, history_path, active_path = parser_module
 
     active_path.write_text("{")


### PR DESCRIPTION
## Summary
- apply Black formatting to openvpn parser logic for routing map initialization
- format parser test case definitions to comply with Black style

## Testing
- black --check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8161f8d64832993832afeb2596337