### PR TITLE
Create local client geolocation cache seeded from history

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -28,3 +28,6 @@ ACTIVE_SESSIONS_PATH = _load_path(
     "OPENVPN_ACTIVE_SESSIONS", "/var/log/openvpn/active_sessions.json"
 )
 SERVER_STATUS_PATH = _load_path("OPENVPN_SERVER_STATUS", "/var/log/openvpn/server_status.json")
+CLIENT_GEO_DB_PATH = _load_path(
+    "OPENVPN_CLIENT_GEO_DB", "/var/log/openvpn/client_geolocation.json"
+)

--- a/app/geo_store.py
+++ b/app/geo_store.py
@@ -1,0 +1,141 @@
+"""Helpers for maintaining the local client geolocation database."""
+
+from __future__ import annotations
+
+import json
+import os
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any, Dict, Iterable, MutableMapping
+
+from .config import CLIENT_GEO_DB_PATH
+
+
+_EMPTY_DB: Dict[str, Any] = {"clients": {}, "updated_at": None}
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _safe_read_json(path: str) -> Dict[str, Any]:
+    if not os.path.exists(path):
+        return deepcopy(_EMPTY_DB)
+
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return deepcopy(_EMPTY_DB)
+
+    if not isinstance(data, MutableMapping):
+        return deepcopy(_EMPTY_DB)
+
+    clients = data.get("clients")
+    if not isinstance(clients, MutableMapping):
+        data["clients"] = {}
+
+    return data
+
+
+def _safe_write_json(path: str, payload: Dict[str, Any]) -> None:
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True, ensure_ascii=False)
+        fh.write("\n")
+
+    os.replace(tmp_path, path)
+
+
+def _ensure_client_record(db: Dict[str, Any], name: str) -> Dict[str, Any]:
+    clients = db.setdefault("clients", {})
+    client = clients.get(name)
+    if client is None:
+        client = {"name": name, "ips": {}, "first_seen": None, "last_seen": None}
+        clients[name] = client
+    return client
+
+
+def _update_seen(record: Dict[str, Any], timestamp: str) -> bool:
+    if not timestamp:
+        return False
+
+    changed = False
+    first_seen = record.get("first_seen")
+    if not first_seen or timestamp < first_seen:
+        record["first_seen"] = timestamp
+        changed = True
+
+    last_seen = record.get("last_seen")
+    if not last_seen or timestamp > last_seen:
+        record["last_seen"] = timestamp
+        changed = True
+
+    return changed
+
+
+def _ensure_ip_record(client: Dict[str, Any], ip: str) -> Dict[str, Any]:
+    ips = client.setdefault("ips", {})
+    ip_record = ips.get(ip)
+    if ip_record is None:
+        ip_record = {
+            "ip": ip,
+            "vpn_ipv4": [],
+            "vpn_ipv6": [],
+            "location": {"latitude": None, "longitude": None, "city": "", "country": ""},
+            "first_seen": None,
+            "last_seen": None,
+        }
+        ips[ip] = ip_record
+    return ip_record
+
+
+def _append_unique(sequence: list, value: str) -> bool:
+    if not value:
+        return False
+    if value in sequence:
+        return False
+    sequence.append(value)
+    return True
+
+
+def ensure_geo_db_entries(history_entries: Iterable[Dict[str, Any]]) -> None:
+    """Ensure that the geolocation DB knows about every client/IP in history."""
+
+    db = _safe_read_json(CLIENT_GEO_DB_PATH)
+    changed = False
+
+    for entry in history_entries:
+        name = entry.get("name")
+        if not name:
+            continue
+
+        client = _ensure_client_record(db, name)
+
+        timestamp = entry.get("timestamp") or ""
+        if _update_seen(client, timestamp):
+            changed = True
+
+        ip = entry.get("ip") or ""
+        if not ip:
+            # Nothing to record if we don't have an external IP.
+            continue
+
+        ip_record = _ensure_ip_record(client, ip)
+        if _update_seen(ip_record, timestamp):
+            changed = True
+
+        if _append_unique(ip_record["vpn_ipv4"], entry.get("vpn_ipv4")):
+            changed = True
+
+        if _append_unique(ip_record["vpn_ipv6"], entry.get("vpn_ipv6")):
+            changed = True
+
+    if changed:
+        db["updated_at"] = _now_utc_iso()
+        _safe_write_json(CLIENT_GEO_DB_PATH, db)
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 from flask import Flask, g, jsonify, render_template
 
 from .config import HISTORY_LOG_PATH, SERVER_STATUS_PATH
+from .geo_store import ensure_geo_db_entries
 from .parser import parse_status_log
 
 
@@ -114,6 +115,8 @@ def _load_history_entries() -> List[Dict[str, Any]]:
             entry = _parse_history_line(parts)
             if entry:
                 entries.append(entry)
+
+    ensure_geo_db_entries(entries)
 
     return entries
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -14,25 +14,28 @@ if str(PROJECT_ROOT) not in sys.path:
 @pytest.fixture
 def app_client(tmp_path, monkeypatch):
     history_path = tmp_path / "history.log"
+    geo_path = tmp_path / "client_geo.json"
 
     monkeypatch.setenv("OPENVPN_HISTORY_LOG", str(history_path))
+    monkeypatch.setenv("OPENVPN_CLIENT_GEO_DB", str(geo_path))
 
     from app import config
 
     importlib.reload(config)
 
-    from app import routes
+    from app import geo_store, routes
 
+    importlib.reload(geo_store)
     importlib.reload(routes)
 
     routes.app.config.update(TESTING=True)
     client = routes.app.test_client()
 
-    return client, history_path
+    return client, history_path, geo_path
 
 
 def test_api_history_includes_vpn_ip_versions(app_client):
-    client, history_path = app_client
+    client, history_path, _ = app_client
 
     history_path.write_text(
         "\n".join(
@@ -63,3 +66,45 @@ def test_api_history_includes_vpn_ip_versions(app_client):
     assert carol["vpn_ip"] == "2001:db8::ffff"
     assert carol["vpn_ipv4"] == ""
     assert carol["vpn_ipv6"] == "2001:db8::ffff"
+
+
+def test_geo_db_populated_from_history(app_client):
+    client, history_path, geo_path = app_client
+
+    history_path.write_text(
+        "\n".join(
+            [
+                "2024-01-01 09:00:00,alice,198.51.100.10,s1,1.0,2.0,10.8.0.5,443,2024-01-01 10:00:00",
+                "2024-01-03 09:00:00,alice,198.51.100.10,s2,1.0,2.0,10.8.0.5,443,2024-01-03 11:00:00",
+                "2024-01-02 09:00:00,bob,203.0.113.5,s3,3.0,4.0,10.9.0.2,1194,2024-01-02 11:00:00,10.9.0.2,2001:db8::abcd",
+            ]
+        )
+    )
+
+    response = client.get("/api/history")
+    assert response.status_code == 200
+
+    assert geo_path.exists()
+
+    payload = json.loads(geo_path.read_text())
+    clients = payload["clients"]
+
+    assert set(clients.keys()) == {"alice", "bob"}
+
+    alice = clients["alice"]
+    assert alice["first_seen"] == "2024-01-01 09:00:00"
+    assert alice["last_seen"] == "2024-01-03 09:00:00"
+    alice_ip = alice["ips"]["198.51.100.10"]
+    assert alice_ip["vpn_ipv4"] == ["10.8.0.5"]
+    assert alice_ip["vpn_ipv6"] == []
+    assert alice_ip["location"] == {
+        "latitude": None,
+        "longitude": None,
+        "city": "",
+        "country": "",
+    }
+
+    bob = clients["bob"]
+    assert bob["first_seen"] == "2024-01-02 09:00:00"
+    bob_ip = bob["ips"]["203.0.113.5"]
+    assert bob_ip["vpn_ipv6"] == ["2001:db8::abcd"]


### PR DESCRIPTION
## Summary
- add configuration for a persistent client geolocation database and helpers to manage it
- populate the geolocation cache from connection history entries when the history API is read
- cover the new behaviour with tests that verify the JSON structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8df1050ac8329928e9784c98132ac