### PR TITLE
Store OpenVPN state files under project data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Thumbs.db
 
 # Flask cache
 instance/
+
+# Application runtime data
+data/

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ cd openvpn-monitor
 
 ### 2. Start the container
 
-Ensure OpenVPN logs are accessible at `/var/log/openvpn/status.log`.
+Ensure OpenVPN logs are accessible at `/var/log/openvpn/status.log`. The application stores its
+state files (history, active sessions, geolocation cache, server status) under the repository
+`data/` directory, which is created automatically on first launch if it does not exist.
 
 ```bash
 docker-compose up --build -d
@@ -58,19 +60,21 @@ docker-compose up --build -d
 
 ### 1. Log directory mount
 
-Verify this volume is properly set in `docker-compose.yml`:
+Verify these volumes are properly set in `docker-compose.yml`:
 
 ```yaml
 volumes:
   - /var/log/openvpn:/var/log/openvpn:rw
+  - ./data:/app/data:rw
 ```
 
 This allows the container to access:
 
 - `status.log`
-- `session_history.log`
-- `active_sessions.json`
-- `server_status.json`
+- `data/active_sessions.json`
+- `data/client_geolocation.json`
+- `data/server_status.json`
+- `data/session_history.log`
 
 ### 2. Traefik domain setup
 
@@ -101,9 +105,10 @@ You can override default log locations and timezone with environment variables:
 |----------|---------|-------------|
 | `OPENVPN_MONITOR_TZ` | `Europe/Bucharest` | Timezone used to compute session durations. |
 | `OPENVPN_STATUS_LOG` | `/var/log/openvpn/status.log` | Path to the OpenVPN status log parsed for active clients. |
-| `OPENVPN_HISTORY_LOG` | `/var/log/openvpn/session_history.log` | File used to persist session history entries. |
-| `OPENVPN_ACTIVE_SESSIONS` | `/var/log/openvpn/active_sessions.json` | JSON file storing in-progress sessions. |
-| `OPENVPN_SERVER_STATUS` | `/var/log/openvpn/server_status.json` | Optional JSON file with aggregated server status information. |
+| `OPENVPN_HISTORY_LOG` | `<project_root>/data/session_history.log` | File used to persist session history entries. |
+| `OPENVPN_ACTIVE_SESSIONS` | `<project_root>/data/active_sessions.json` | JSON file storing in-progress sessions. |
+| `OPENVPN_SERVER_STATUS` | `<project_root>/data/server_status.json` | Optional JSON file with aggregated server status information. |
+| `OPENVPN_CLIENT_GEO_DB` | `<project_root>/data/client_geolocation.json` | Local cache of IP geolocation metadata. |
 
 Example `docker-compose.yml` override:
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,10 +1,14 @@
 """Application configuration helpers for log parsing and API."""
 
+import json
 import os
+from pathlib import Path
 
 import pytz
 
 _DEFAULT_TIMEZONE = "Europe/Bucharest"
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_DATA_DIR = _PROJECT_ROOT / "data"
 
 
 def _load_timezone():
@@ -21,13 +25,46 @@ def _load_path(env_var: str, default: str) -> str:
     return os.path.expanduser(path)
 
 
+def _default_data_path(filename: str) -> str:
+    return str(_DEFAULT_DATA_DIR / filename)
+
+
+def _ensure_data_files(targets) -> None:
+    for raw_path, payload in targets.items():
+        path = Path(raw_path)
+        directory = path.parent
+        if directory:
+            directory.mkdir(parents=True, exist_ok=True)
+
+        if path.exists():
+            continue
+
+        if payload is None:
+            path.touch()
+            continue
+
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+
 LOCAL_TZ = _load_timezone()
 STATUS_LOG_PATH = _load_path("OPENVPN_STATUS_LOG", "/var/log/openvpn/status.log")
-HISTORY_LOG_PATH = _load_path("OPENVPN_HISTORY_LOG", "/var/log/openvpn/session_history.log")
+HISTORY_LOG_PATH = _load_path("OPENVPN_HISTORY_LOG", _default_data_path("session_history.log"))
 ACTIVE_SESSIONS_PATH = _load_path(
-    "OPENVPN_ACTIVE_SESSIONS", "/var/log/openvpn/active_sessions.json"
+    "OPENVPN_ACTIVE_SESSIONS", _default_data_path("active_sessions.json")
 )
-SERVER_STATUS_PATH = _load_path("OPENVPN_SERVER_STATUS", "/var/log/openvpn/server_status.json")
+SERVER_STATUS_PATH = _load_path("OPENVPN_SERVER_STATUS", _default_data_path("server_status.json"))
 CLIENT_GEO_DB_PATH = _load_path(
-    "OPENVPN_CLIENT_GEO_DB", "/var/log/openvpn/client_geolocation.json"
+    "OPENVPN_CLIENT_GEO_DB", _default_data_path("client_geolocation.json")
+)
+
+_ensure_data_files(
+    {
+        HISTORY_LOG_PATH: None,
+        ACTIVE_SESSIONS_PATH: {},
+        SERVER_STATUS_PATH: {},
+        CLIENT_GEO_DB_PATH: {"clients": {}, "updated_at": None},
+    }
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: openvpn-admin
     volumes:
       - /var/log/openvpn:/var/log/openvpn:rw  # Mounting OpenVPN logs into a container
-      - ./data:/var/log/openvpn/data:rw  # Data folder 
+      - ./data:/app/data:rw  # Persist application state files
     #ports:
     #  - 5000:5000
     labels:


### PR DESCRIPTION
## Summary
- default OpenVPN runtime artifacts now live in the project's data/ directory and are created automatically when missing
- document the new locations and mount requirements for Docker deployments
- ignore the generated data/ directory in version control

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d920506020832998e4617c178c9b15