### PR TITLE
Prevent duplicate history records from concurrent parsing

### DIFF
--- a/app/parser.py
+++ b/app/parser.py
@@ -96,6 +96,23 @@ def history_log(path: str = HISTORY_LOG_PATH):
             fcntl.flock(logf, fcntl.LOCK_UN)
 
 
+@contextmanager
+def active_sessions_lock(path: str = ACTIVE_SESSIONS_PATH):
+    """Prevent concurrent modifications of the active sessions state."""
+
+    target_path = os.path.abspath(path)
+    directory = os.path.dirname(target_path)
+    os.makedirs(directory, exist_ok=True)
+
+    lock_path = f"{target_path}.lock"
+    with open(lock_path, "w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
 def _split_real_address(address: str):
     if not address:
         return "", ""
@@ -125,194 +142,197 @@ def _split_real_address(address: str):
 
 def parse_status_log(filepath=STATUS_LOG_PATH):
     clients = []
-    active_sessions = load_active_sessions()
     current_common_names = set()
     vpn_ip_map = {}
     new_sessions = []
     client_records = []
-    now = datetime.datetime.now(LOCAL_TZ)
 
     try:
-        with open(filepath, "r") as f:
-            section = None
+        with active_sessions_lock():
+            active_sessions = load_active_sessions()
+            now = datetime.datetime.now(LOCAL_TZ)
 
-            for raw_line in f:
-                line = raw_line.strip()
+            with open(filepath, "r") as f:
+                section = None
 
-                if raw_line.startswith(
-                    "Common Name,Real Address,Bytes Received,Bytes Sent,Connected Since"
-                ):
-                    section = "clients"
-                    continue
+                for raw_line in f:
+                    line = raw_line.strip()
 
-                if raw_line.startswith("ROUTING TABLE"):
-                    section = "routing"
-                    continue
-
-                if raw_line.startswith("GLOBAL STATS"):
-                    section = None
-                    continue
-
-                if not line:
-                    if section in {"clients", "routing"}:
-                        section = None
-                    continue
-
-                if section == "routing":
-                    parts = line.split(",")
-                    if len(parts) >= 2:
-                        vpn_ip = parts[0].strip()
-                        common_name = parts[1].strip()
-
-                        entry = vpn_ip_map.setdefault(common_name, {"ipv4": None, "ipv6": None})
-
-                        try:
-                            ip_obj = ip_address(vpn_ip)
-                        except ValueError:
-                            # Fallback to the previous behaviour – store the value in the
-                            # first available slot so we don't lose potentially useful
-                            # information even if it isn't a valid IP.
-                            if entry["ipv4"] is None:
-                                entry["ipv4"] = vpn_ip
-                            elif entry["ipv6"] is None:
-                                entry["ipv6"] = vpn_ip
-                            continue
-
-                        if ip_obj.version == 4:
-                            entry["ipv4"] = vpn_ip
-                        else:
-                            entry["ipv6"] = vpn_ip
-                    continue
-
-                if section == "clients":
-                    parts = line.split(",")
-                    if len(parts) < 5:
+                    if raw_line.startswith(
+                        "Common Name,Real Address,Bytes Received,Bytes Sent,Connected Since"
+                    ):
+                        section = "clients"
                         continue
 
-                    common_name = parts[0]
-                    real_ip, port = _split_real_address(parts[1])
-                    bytes_received = int(parts[2])
-                    bytes_sent = int(parts[3])
-                    connected_since = parts[4]
+                    if raw_line.startswith("ROUTING TABLE"):
+                        section = "routing"
+                        continue
 
-                    naive_dt = datetime.datetime.strptime(connected_since, "%Y-%m-%d %H:%M:%S")
-                    connected_dt = LOCAL_TZ.localize(naive_dt)
-                    time_online = format_duration(int((now - connected_dt).total_seconds()))
+                    if raw_line.startswith("GLOBAL STATS"):
+                        section = None
+                        continue
 
-                    client_records.append(
-                        {
-                            "common_name": common_name,
-                            "real_ip": real_ip,
-                            "port": port,
-                            "bytes_received": bytes_received,
-                            "bytes_sent": bytes_sent,
-                            "connected_since": connected_since,
-                            "time_online": time_online,
-                        }
+                    if not line:
+                        if section in {"clients", "routing"}:
+                            section = None
+                        continue
+
+                    if section == "routing":
+                        parts = line.split(",")
+                        if len(parts) >= 2:
+                            vpn_ip = parts[0].strip()
+                            common_name = parts[1].strip()
+
+                            entry = vpn_ip_map.setdefault(common_name, {"ipv4": None, "ipv6": None})
+
+                            try:
+                                ip_obj = ip_address(vpn_ip)
+                            except ValueError:
+                                # Fallback to the previous behaviour – store the value in the
+                                # first available slot so we don't lose potentially useful
+                                # information even if it isn't a valid IP.
+                                if entry["ipv4"] is None:
+                                    entry["ipv4"] = vpn_ip
+                                elif entry["ipv6"] is None:
+                                    entry["ipv6"] = vpn_ip
+                                continue
+
+                            if ip_obj.version == 4:
+                                entry["ipv4"] = vpn_ip
+                            else:
+                                entry["ipv6"] = vpn_ip
+                        continue
+
+                    if section == "clients":
+                        parts = line.split(",")
+                        if len(parts) < 5:
+                            continue
+
+                        common_name = parts[0]
+                        real_ip, port = _split_real_address(parts[1])
+                        bytes_received = int(parts[2])
+                        bytes_sent = int(parts[3])
+                        connected_since = parts[4]
+
+                        naive_dt = datetime.datetime.strptime(connected_since, "%Y-%m-%d %H:%M:%S")
+                        connected_dt = LOCAL_TZ.localize(naive_dt)
+                        time_online = format_duration(int((now - connected_dt).total_seconds()))
+
+                        client_records.append(
+                            {
+                                "common_name": common_name,
+                                "real_ip": real_ip,
+                                "port": port,
+                                "bytes_received": bytes_received,
+                                "bytes_sent": bytes_sent,
+                                "connected_since": connected_since,
+                                "time_online": time_online,
+                            }
+                        )
+
+                        current_common_names.add(common_name)
+
+                        if common_name not in active_sessions:
+                            session_id = str(uuid.uuid4())
+                            active_sessions[common_name] = {
+                                "ip": real_ip,
+                                "vpn_ip": None,
+                                "vpn_ipv4": None,
+                                "vpn_ipv6": None,
+                                "connected_at": connected_dt.strftime("%Y-%m-%d %H:%M:%S"),
+                                "bytes_received": bytes_received,
+                                "bytes_sent": bytes_sent,
+                                "port": port,
+                                "session_id": session_id,
+                            }
+                            new_sessions.append(common_name)
+                        else:
+                            active_sessions[common_name]["bytes_received"] = bytes_received
+                            active_sessions[common_name]["bytes_sent"] = bytes_sent
+                            active_sessions[common_name]["ip"] = real_ip
+                            active_sessions[common_name]["port"] = port
+
+            for record in client_records:
+                common_name = record["common_name"]
+                vpn_ip_entry = vpn_ip_map.get(common_name, {})
+                vpn_ipv4 = vpn_ip_entry.get("ipv4") if isinstance(vpn_ip_entry, dict) else None
+                vpn_ipv6 = vpn_ip_entry.get("ipv6") if isinstance(vpn_ip_entry, dict) else None
+
+                vpn_ip = vpn_ipv4 or vpn_ipv6
+
+                record["vpn_ip"] = vpn_ip
+                record["vpn_ipv4"] = vpn_ipv4
+                record["vpn_ipv6"] = vpn_ipv6
+                clients.append(record)
+
+                if common_name in active_sessions:
+                    active_sessions[common_name]["vpn_ip"] = vpn_ip
+                    active_sessions[common_name]["vpn_ipv4"] = vpn_ipv4
+                    active_sessions[common_name]["vpn_ipv6"] = vpn_ipv6
+
+            for common_name in new_sessions:
+                session = active_sessions.get(common_name)
+                if not session:
+                    continue
+
+                vpn_ip_entry = vpn_ip_map.get(common_name)
+                if isinstance(vpn_ip_entry, dict):
+                    vpn_ipv4 = vpn_ip_entry.get("ipv4") or ""
+                    vpn_ipv6 = vpn_ip_entry.get("ipv6") or ""
+                else:
+                    value = vpn_ip_entry or ""
+                    vpn_ipv4 = value
+                    vpn_ipv6 = ""
+                    try:
+                        if value:
+                            ip_obj = ip_address(value)
+                            if ip_obj.version == 6:
+                                vpn_ipv4, vpn_ipv6 = "", value
+                    except ValueError:
+                        pass
+                vpn_ip = vpn_ipv4 or vpn_ipv6 or ""
+                port = session.get("port") or ""
+
+                session["vpn_ip"] = vpn_ip or None
+                session["vpn_ipv4"] = vpn_ipv4 or None
+                session["vpn_ipv6"] = vpn_ipv6 or None
+
+                with history_log() as logf:
+                    logf.write(
+                        f"{session['connected_at']},{common_name},{session['ip']},{session['session_id']},,,,{vpn_ip},{port},,{vpn_ipv4},{vpn_ipv6}\n"
                     )
 
-                    current_common_names.add(common_name)
+            disconnected = [cn for cn in list(active_sessions) if cn not in current_common_names]
+            for cn in disconnected:
+                session = active_sessions[cn]
+                rx = round(session["bytes_received"] / (1024 * 1024), 2)
+                tx = round(session["bytes_sent"] / (1024 * 1024), 2)
+                disconnect_time = now.strftime("%Y-%m-%d %H:%M:%S")
+                vpn_ip = session.get("vpn_ip") or ""
+                port = session.get("port") or ""
+                vpn_ipv4 = session.get("vpn_ipv4") or ""
+                vpn_ipv6 = session.get("vpn_ipv6") or ""
 
-                    if common_name not in active_sessions:
-                        session_id = str(uuid.uuid4())
-                        active_sessions[common_name] = {
-                            "ip": real_ip,
-                            "vpn_ip": None,
-                            "vpn_ipv4": None,
-                            "vpn_ipv6": None,
-                            "connected_at": connected_dt.strftime("%Y-%m-%d %H:%M:%S"),
-                            "bytes_received": bytes_received,
-                            "bytes_sent": bytes_sent,
-                            "port": port,
-                            "session_id": session_id,
-                        }
-                        new_sessions.append(common_name)
+                if not vpn_ipv4 and not vpn_ipv6 and vpn_ip:
+                    try:
+                        ip_obj = ip_address(vpn_ip)
+                    except ValueError:
+                        pass
                     else:
-                        active_sessions[common_name]["bytes_received"] = bytes_received
-                        active_sessions[common_name]["bytes_sent"] = bytes_sent
-                        active_sessions[common_name]["ip"] = real_ip
-                        active_sessions[common_name]["port"] = port
+                        if ip_obj.version == 4:
+                            vpn_ipv4 = vpn_ip
+                        else:
+                            vpn_ipv6 = vpn_ip
 
-        for record in client_records:
-            common_name = record["common_name"]
-            vpn_ip_entry = vpn_ip_map.get(common_name, {})
-            vpn_ipv4 = vpn_ip_entry.get("ipv4") if isinstance(vpn_ip_entry, dict) else None
-            vpn_ipv6 = vpn_ip_entry.get("ipv6") if isinstance(vpn_ip_entry, dict) else None
+                with history_log() as logf:
+                    logf.write(
+                        f"{session['connected_at']},{cn},{session['ip']},{session['session_id']},{rx},{tx},{vpn_ip},{port},{disconnect_time},{vpn_ipv4},{vpn_ipv6}\n"
+                    )
 
-            vpn_ip = vpn_ipv4 or vpn_ipv6
+                del active_sessions[cn]
 
-            record["vpn_ip"] = vpn_ip
-            record["vpn_ipv4"] = vpn_ipv4
-            record["vpn_ipv6"] = vpn_ipv6
-            clients.append(record)
-
-            if common_name in active_sessions:
-                active_sessions[common_name]["vpn_ip"] = vpn_ip
-                active_sessions[common_name]["vpn_ipv4"] = vpn_ipv4
-                active_sessions[common_name]["vpn_ipv6"] = vpn_ipv6
-
-        for common_name in new_sessions:
-            session = active_sessions.get(common_name)
-            if not session:
-                continue
-
-            vpn_ip_entry = vpn_ip_map.get(common_name)
-            if isinstance(vpn_ip_entry, dict):
-                vpn_ipv4 = vpn_ip_entry.get("ipv4") or ""
-                vpn_ipv6 = vpn_ip_entry.get("ipv6") or ""
-            else:
-                value = vpn_ip_entry or ""
-                vpn_ipv4 = value
-                vpn_ipv6 = ""
-                try:
-                    if value:
-                        ip_obj = ip_address(value)
-                        if ip_obj.version == 6:
-                            vpn_ipv4, vpn_ipv6 = "", value
-                except ValueError:
-                    pass
-            vpn_ip = vpn_ipv4 or vpn_ipv6 or ""
-            port = session.get("port") or ""
-
-            session["vpn_ip"] = vpn_ip or None
-            session["vpn_ipv4"] = vpn_ipv4 or None
-            session["vpn_ipv6"] = vpn_ipv6 or None
-
-            with history_log() as logf:
-                logf.write(
-                    f"{session['connected_at']},{common_name},{session['ip']},{session['session_id']},,,,{vpn_ip},{port},,{vpn_ipv4},{vpn_ipv6}\n"
-                )
-
-        disconnected = [cn for cn in list(active_sessions) if cn not in current_common_names]
-        for cn in disconnected:
-            session = active_sessions[cn]
-            rx = round(session["bytes_received"] / (1024 * 1024), 2)
-            tx = round(session["bytes_sent"] / (1024 * 1024), 2)
-            disconnect_time = now.strftime("%Y-%m-%d %H:%M:%S")
-            vpn_ip = session.get("vpn_ip") or ""
-            port = session.get("port") or ""
-            vpn_ipv4 = session.get("vpn_ipv4") or ""
-            vpn_ipv6 = session.get("vpn_ipv6") or ""
-
-            if not vpn_ipv4 and not vpn_ipv6 and vpn_ip:
-                try:
-                    ip_obj = ip_address(vpn_ip)
-                except ValueError:
-                    pass
-                else:
-                    if ip_obj.version == 4:
-                        vpn_ipv4 = vpn_ip
-                    else:
-                        vpn_ipv6 = vpn_ip
-
-            with history_log() as logf:
-                logf.write(
-                    f"{session['connected_at']},{cn},{session['ip']},{session['session_id']},{rx},{tx},{vpn_ip},{port},{disconnect_time},{vpn_ipv4},{vpn_ipv6}\n"
-                )
-
-            del active_sessions[cn]
+            save_active_sessions(active_sessions)
     except Exception:  # pragma: no cover - safeguard logging
         logger.exception("Error parsing status log")
 
-    save_active_sessions(active_sessions)
     return clients


### PR DESCRIPTION
## Summary
- serialize access to the active sessions state to avoid writing duplicate history rows when multiple parsers run concurrently
- add a regression test that exercises simultaneous parses and ensures only a single history record is written

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9298906e88329a8f66126ec12ef6c