### PR TITLE
Switch session history storage to JSON

### DIFF
--- a/Docs/REVIEW.md
+++ b/Docs/REVIEW.md
@@ -3,7 +3,7 @@
 ## Parser (`app/parser.py`)
 - `LOCAL_TZ` is hard-coded to `Europe/Bucharest`; timezone/log paths should be configurable via environment or config to avoid incorrect calculations when deployed elsewhere. This also makes unit testing harder because the parser relies on the host time zone. 【F:app/parser.py†L9-L11】
 - `parse_status_log` reads the entire log into memory and then iterates twice (once for the routing table, once for clients). Streaming the file once would lower overhead and reduce latency for large logs that the API polls every few seconds. 【F:app/parser.py†L26-L79】
-- Every API call triggers updates to `active_sessions.json`/`session_history.log`. Without file locking this risks race conditions (corrupted JSON, duplicate history rows) once multiple workers or the background logger run concurrently. 【F:app/parser.py†L18-L25】【F:app/parser.py†L96-L123】
+- Every API call triggers updates to `active_sessions.json`/`session_history.json`. Without file locking this risks race conditions (corrupted JSON, duplicate history rows) once multiple workers or the background logger run concurrently. 【F:app/parser.py†L18-L25】【F:app/parser.py†L96-L123】
 - Error handling falls back to `print` statements; replacing them with the standard `logging` module and returning meaningful HTTP errors would simplify debugging and play better with production log aggregation. 【F:app/parser.py†L124-L127】
 - IPv6 addresses skip port extraction by setting `port = None`, yet later history writes interpolate `{port}`, yielding the literal string `None`. Consider storing explicit empty strings or retaining the socket pair to avoid confusing UI consumers. 【F:app/parser.py†L57-L106】
 
@@ -24,7 +24,7 @@
 
 - parse_status_log читает файл целиком и проходит по нему дважды, что создаёт лишнюю нагрузку при больших логах и частом опросе API; оптимальнее обрабатывать потоково за один проход. 
 
-- Активные сессии сохраняются в JSON без какой-либо синхронизации, а каждый HTTP‑запрос модифицирует active_sessions.json и session_history.log; при параллельных процессах высок риск гонок и повреждения данных. 
+- Активные сессии сохраняются в JSON без какой-либо синхронизации, а каждый HTTP‑запрос модифицирует active_sessions.json и session_history.json; при параллельных процессах высок риск гонок и повреждения данных.
 
 - Обработка ошибок сводится к print, поэтому ошибки теряются в продакшене; стоит перейти на стандартный logging и возвращать более информативные ответы API. 
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This allows the container to access:
 - `data/active_sessions.json`
 - `data/client_geolocation.json`
 - `data/server_status.json`
-- `data/session_history.log`
+- `data/session_history.json`
 
 ### 2. Traefik domain setup
 
@@ -105,7 +105,7 @@ You can override default log locations and timezone with environment variables:
 |----------|---------|-------------|
 | `OPENVPN_MONITOR_TZ` | `Europe/Bucharest` | Timezone used to compute session durations. |
 | `OPENVPN_STATUS_LOG` | `/var/log/openvpn/status.log` | Path to the OpenVPN status log parsed for active clients. |
-| `OPENVPN_HISTORY_LOG` | `<project_root>/data/session_history.log` | File used to persist session history entries. |
+| `OPENVPN_HISTORY_LOG` | `<project_root>/data/session_history.json` | File used to persist session history entries. |
 | `OPENVPN_ACTIVE_SESSIONS` | `<project_root>/data/active_sessions.json` | JSON file storing in-progress sessions. |
 | `OPENVPN_SERVER_STATUS` | `<project_root>/data/server_status.json` | Optional JSON file with aggregated server status information. |
 | `OPENVPN_CLIENT_GEO_DB` | `<project_root>/data/client_geolocation.json` | Local cache of IP geolocation metadata. |

--- a/app/config.py
+++ b/app/config.py
@@ -51,7 +51,7 @@ def _ensure_data_files(targets) -> None:
 
 LOCAL_TZ = _load_timezone()
 STATUS_LOG_PATH = _load_path("OPENVPN_STATUS_LOG", "/var/log/openvpn/status.log")
-HISTORY_LOG_PATH = _load_path("OPENVPN_HISTORY_LOG", _default_data_path("session_history.log"))
+HISTORY_LOG_PATH = _load_path("OPENVPN_HISTORY_LOG", _default_data_path("session_history.json"))
 ACTIVE_SESSIONS_PATH = _load_path(
     "OPENVPN_ACTIVE_SESSIONS", _default_data_path("active_sessions.json")
 )
@@ -62,7 +62,7 @@ CLIENT_GEO_DB_PATH = _load_path(
 
 _ensure_data_files(
     {
-        HISTORY_LOG_PATH: None,
+        HISTORY_LOG_PATH: [],
         ACTIVE_SESSIONS_PATH: {},
         SERVER_STATUS_PATH: {},
         CLIENT_GEO_DB_PATH: {"clients": {}, "updated_at": None},


### PR DESCRIPTION
## Summary
- replace the CSV-based session history log with a JSON file and update configuration defaults
- rewrite parser history persistence and API loaders to append and read structured JSON entries
- refresh documentation and tests to cover the new session_history.json format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d92cf6e0a483299d2edcb483515f3c