### PR TITLE
Persist server status responses

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
@@ -261,6 +262,28 @@ def _load_server_status() -> Dict[str, Any]:
     return data
 
 
+def _write_server_status(data: Dict[str, Any]) -> None:
+    directory = os.path.dirname(SERVER_STATUS_PATH)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+    temp_dir = directory or "."
+    fd, temp_path = tempfile.mkstemp(dir=temp_dir, prefix="server_status_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            json.dump(data, tmp_file, ensure_ascii=False, sort_keys=True)
+            tmp_file.write("\n")
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        os.replace(temp_path, SERVER_STATUS_PATH)
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("[server-status] Failed to persist server status")
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+
+
 @app.route("/")
 def index():
     return render_template("index.html")
@@ -314,6 +337,8 @@ def get_server_status():
             "total_tx": round(total_tx / 1024 / 1024, 2),
         }
     )
+
+    _write_server_status(data)
 
     return jsonify(data)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -15,9 +15,11 @@ if str(PROJECT_ROOT) not in sys.path:
 def app_client(tmp_path, monkeypatch):
     history_path = tmp_path / "history.json"
     geo_path = tmp_path / "client_geo.json"
+    server_status_path = tmp_path / "server_status.json"
 
     monkeypatch.setenv("OPENVPN_HISTORY_LOG", str(history_path))
     monkeypatch.setenv("OPENVPN_CLIENT_GEO_DB", str(geo_path))
+    monkeypatch.setenv("OPENVPN_SERVER_STATUS", str(server_status_path))
 
     from app import config
 
@@ -31,11 +33,11 @@ def app_client(tmp_path, monkeypatch):
     routes.app.config.update(TESTING=True)
     client = routes.app.test_client()
 
-    return client, history_path, geo_path
+    return client, history_path, geo_path, server_status_path
 
 
 def test_api_history_includes_vpn_ip_versions(app_client):
-    client, history_path, _ = app_client
+    client, history_path, _, _ = app_client
 
     history_entries = [
         {
@@ -102,7 +104,7 @@ def test_api_history_includes_vpn_ip_versions(app_client):
 
 
 def test_geo_db_populated_from_history(app_client):
-    client, history_path, geo_path = app_client
+    client, history_path, geo_path, _ = app_client
 
     history_entries = [
         {
@@ -177,7 +179,7 @@ def test_geo_db_populated_from_history(app_client):
 
 
 def test_clients_summary_counts_closed_sessions(app_client, monkeypatch):
-    client, history_path, _ = app_client
+    client, history_path, _, _ = app_client
 
     history_entries = [
         {
@@ -234,7 +236,7 @@ def test_clients_summary_counts_closed_sessions(app_client, monkeypatch):
 
 
 def test_clients_summary_includes_active_session(app_client, monkeypatch):
-    client, history_path, _ = app_client
+    client, history_path, _, _ = app_client
 
     history_entries = [
         {
@@ -277,3 +279,47 @@ def test_clients_summary_includes_active_session(app_client, monkeypatch):
     payload = json.loads(response.data)
     assert payload["clients"][0]["sessions"] == 2
     assert payload["clients"][0]["is_online"] is True
+
+
+def test_server_status_endpoint_persists_response(app_client, monkeypatch):
+    client, _, _, server_status_path = app_client
+
+    initial_status = {
+        "status": "Running",
+        "uptime": "3 days",
+        "local_ip": "10.0.0.1",
+        "public_ip": "203.0.113.1",
+        "pingable": "yes",
+    }
+    server_status_path.write_text(json.dumps(initial_status))
+
+    from app import routes
+
+    sample_clients = [
+        {
+            "common_name": "alice",
+            "bytes_received": 5 * 1024 * 1024,
+            "bytes_sent": 3 * 1024 * 1024,
+        },
+        {
+            "common_name": "bob",
+            "bytes_received": 7 * 1024 * 1024,
+            "bytes_sent": 9 * 1024 * 1024,
+        },
+    ]
+
+    monkeypatch.setattr(routes, "parse_status_log", lambda: sample_clients)
+
+    response = client.get("/api/server-status")
+    assert response.status_code == 200
+
+    payload = response.get_json()
+
+    assert payload["mode"] == "server"
+    assert payload["clients"] == 2
+    assert payload["pingable"] is True
+    assert payload["total_rx"] == 12.0
+    assert payload["total_tx"] == 12.0
+
+    saved_payload = json.loads(server_status_path.read_text())
+    assert saved_payload == payload


### PR DESCRIPTION
## Summary
- add an atomic helper that writes the assembled server-status payload to disk
- refresh the stored JSON after each /api/server-status call and cover it with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9407ff8148329b815127b97d89a3a