### PR TITLE
Remove server_status.json references

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ This allows the container to access:
 - `status.log`
 - `data/active_sessions.json`
 - `data/client_geolocation.json`
-- `data/server_status.json`
 - `data/session_history.json`
 
 ### 2. Traefik domain setup
@@ -107,7 +106,6 @@ You can override default log locations and timezone with environment variables:
 | `OPENVPN_STATUS_LOG` | `/var/log/openvpn/status.log` | Path to the OpenVPN status log parsed for active clients. |
 | `OPENVPN_HISTORY_LOG` | `<project_root>/data/session_history.json` | File used to persist session history entries. |
 | `OPENVPN_ACTIVE_SESSIONS` | `<project_root>/data/active_sessions.json` | JSON file storing in-progress sessions. |
-| `OPENVPN_SERVER_STATUS` | `<project_root>/data/server_status.json` | Optional JSON file with aggregated server status information. |
 | `OPENVPN_CLIENT_GEO_DB` | `<project_root>/data/client_geolocation.json` | Local cache of IP geolocation metadata. |
 
 Example `docker-compose.yml` override:

--- a/app/config.py
+++ b/app/config.py
@@ -55,7 +55,6 @@ HISTORY_LOG_PATH = _load_path("OPENVPN_HISTORY_LOG", _default_data_path("session
 ACTIVE_SESSIONS_PATH = _load_path(
     "OPENVPN_ACTIVE_SESSIONS", _default_data_path("active_sessions.json")
 )
-SERVER_STATUS_PATH = _load_path("OPENVPN_SERVER_STATUS", _default_data_path("server_status.json"))
 CLIENT_GEO_DB_PATH = _load_path(
     "OPENVPN_CLIENT_GEO_DB", _default_data_path("client_geolocation.json")
 )
@@ -64,7 +63,6 @@ _ensure_data_files(
     {
         HISTORY_LOG_PATH: [],
         ACTIVE_SESSIONS_PATH: {},
-        SERVER_STATUS_PATH: {},
         CLIENT_GEO_DB_PATH: {"clients": {}, "updated_at": None},
     }
 )

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -658,24 +658,66 @@ function escapeHtml(value) {
 
 
 function formatUptime(uptimeStr) {
+  if (!uptimeStr) return '';
   const uptime = new Date(uptimeStr);
   const now = new Date();
   const diffMs = now - uptime;
-  if (isNaN(uptime.getTime()) || diffMs < 0) return "Unknown";
+  if (isNaN(uptime.getTime()) || diffMs < 0) return '';
   const minutes = Math.floor(diffMs / 60000);
   const hours = Math.floor(minutes / 60);
   const days = Math.floor(hours / 24);
   return `${days > 0 ? days + "d " : ""}${hours % 24}h ${minutes % 60}m`;
 }
 
+function formatPingable(value) {
+  if (value === null || value === undefined || value === '') return '';
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['yes', 'true', '1'].includes(normalized)) return 'Yes';
+    if (['no', 'false', '0'].includes(normalized)) return 'No';
+    return value;
+  }
+  return value ? 'Yes' : 'No';
+}
+
+function ensureString(value) {
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+function formatWithUnit(value, unit) {
+  const text = ensureString(value);
+  if (text === '') return '';
+  return `${text} ${unit}`;
+}
+
 function fetchServerStatus() {
   fetch("/api/server-status")
     .then(r => r.json())
     .then(data => {
+      const status = {
+        mode: '',
+        status: '',
+        pingable: '',
+        clients: '',
+        total_rx: '',
+        total_tx: '',
+        uptime: '',
+        local_ip: '',
+        public_ip: '',
+        ...(data || {})
+      };
+
       const row = `<tr>
-        <td>${data.mode}</td><td>${data.status}</td><td>${data.pingable}</td>
-        <td>${data.clients}</td><td>${data.total_rx} MB</td><td>${data.total_tx} MB</td>
-        <td>${formatUptime(data.uptime)}</td><td>${data.local_ip}</td><td>${data.public_ip}</td>
+        <td>${escapeHtml(ensureString(status.mode))}</td>
+        <td>${escapeHtml(ensureString(status.status))}</td>
+        <td>${escapeHtml(ensureString(formatPingable(status.pingable)))}</td>
+        <td>${escapeHtml(ensureString(status.clients))}</td>
+        <td>${escapeHtml(formatWithUnit(status.total_rx, 'MB'))}</td>
+        <td>${escapeHtml(formatWithUnit(status.total_tx, 'MB'))}</td>
+        <td>${escapeHtml(formatUptime(status.uptime))}</td>
+        <td>${escapeHtml(ensureString(status.local_ip))}</td>
+        <td>${escapeHtml(ensureString(status.public_ip))}</td>
       </tr>`;
       document.getElementById("server-status-body").innerHTML = row;
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
 #      OPENVPN_STATUS_LOG: "/var/log/openvpn/status.log"
 #      OPENVPN_HISTORY_LOG: "./data/session_history.json"
 #      OPENVPN_ACTIVE_SESSIONS: "./data/active_sessions.json"
-#      OPENVPN_SERVER_STATUS: "./data/server_status.json"
 #      OPENVPN_CLIENT_GEO_DB: "./data/client_geolocation.json"
     volumes:
       - /var/log/openvpn:/var/log/openvpn:rw  # Mounting OpenVPN logs into a container


### PR DESCRIPTION
## Summary
- remove the server_status.json configuration path and file bootstrap
- simplify the server-status API and UI rendering to use empty placeholder values
- update documentation and docker-compose comments to drop references to server_status.json

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da58c143a483298ace5e71e249719a