### PR TITLE
Fix outline button focus colors

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -15,27 +15,35 @@
 
 /* Dark theme: improve outline button visibility */
 [data-bs-theme="dark"] .btn-outline-dark {
-  color: #f8f9fa;
-  border-color: #f8f9fa;
-}
-
-[data-bs-theme="dark"] .btn-outline-dark:hover,
-[data-bs-theme="dark"] .btn-outline-dark:focus {
-  color: #212529;
-  background-color: #f8f9fa;
-  border-color: #f8f9fa;
+  --bs-btn-color: #f8f9fa;
+  --bs-btn-border-color: #f8f9fa;
+  --bs-btn-hover-color: #212529;
+  --bs-btn-hover-bg: #f8f9fa;
+  --bs-btn-hover-border-color: #f8f9fa;
+  --bs-btn-focus-shadow-rgb: 248, 249, 250;
 }
 
 [data-bs-theme="dark"] .btn-outline-secondary {
-  color: #f8f9fa;
-  border-color: #ced4da;
+  --bs-btn-color: #f8f9fa;
+  --bs-btn-border-color: #ced4da;
+  --bs-btn-hover-color: #212529;
+  --bs-btn-hover-bg: #ced4da;
+  --bs-btn-hover-border-color: #ced4da;
+  --bs-btn-focus-shadow-rgb: 206, 212, 218;
 }
 
-[data-bs-theme="dark"] .btn-outline-secondary:hover,
-[data-bs-theme="dark"] .btn-outline-secondary:focus {
-  color: #212529;
-  background-color: #ced4da;
-  border-color: #ced4da;
+.btn-outline-dark:focus:not(:focus-visible),
+.btn-outline-secondary:focus:not(:focus-visible) {
+  color: var(--bs-btn-color);
+  background-color: var(--bs-btn-bg);
+  border-color: var(--bs-btn-border-color);
+}
+
+.btn-outline-dark:focus-visible,
+.btn-outline-secondary:focus-visible {
+  color: var(--bs-btn-hover-color);
+  background-color: var(--bs-btn-hover-bg);
+  border-color: var(--bs-btn-hover-border-color);
 }
 
 /* Dark theme: ensure background is dark */


### PR DESCRIPTION
## Summary
- update outline button styling so mouse clicks no longer leave hover colors applied
- align dark theme outline buttons with Bootstrap variables to keep hover/keyboard feedback consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8c4b1d1b483298ba235381e4ab565