### PR TITLE
Fix dark theme button text visibility on hover

### DIFF
--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -52,7 +52,8 @@ function toggleTheme() {
 
   // === TEXT ELEMENTS ===
   // Toggle color for headings, table cells, and form elements
-  toggle("h1, h2, h3, h4, h5, h6, th, label, button", "text-light", "text-dark");
+  // Buttons rely on their own Bootstrap variables for contrast, so exclude them
+  toggle("h1, h2, h3, h4, h5, h6, th, label", "text-light", "text-dark");
 
   // === FORM ELEMENTS ===
   // Toggle input field background


### PR DESCRIPTION
## Summary
- prevent the theme toggle from forcing text-light/text-dark classes onto buttons
- allow outline buttons to keep their Bootstrap contrast variables so text remains visible when hovering in dark mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8f007171c8329801c20618f44dfa2